### PR TITLE
Return address for imported wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,3 +130,9 @@ Deprecated package was `@getsafle/bsc-wallet-controller` and updated one is `@ge
 ##### List active chains
 
 * Created a method to get the list of chains for which the user has generated or imported a wallet.
+
+### 1.5.1 (2022-01-31)
+
+##### Import wallet function return the public address
+
+* Updated the importWallet function to return the public address of the private key along with the encrypted vault string.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/safle-vault",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Safle Vault is a non-custodial, flexible and highly available crypto wallet which can be used to access dapps, send/receive crypto and store identity. Vault SDK is used to manage the vault and provide methods to generate vault, add new accounts, update the state and also enable the user to perform several vault related operations.",
   "main": "src/index.js",
   "scripts": {

--- a/src/lib/keyring.js
+++ b/src/lib/keyring.js
@@ -321,8 +321,10 @@ class Keyring {
 
         const encryptedPrivKey = cryptojs.AES.encrypt(privateKey, pin).toString();
 
+        let address;
+
         if (Chains.evmChains.includes(this.chain) || this.chain === 'ethereum') {
-            const address = await this.keyringInstance.importWallet(privateKey);
+            address = await this.keyringInstance.importWallet(privateKey);
 
             if(this.decryptedVault.importedWallets === undefined) {    
                 this.decryptedVault.importedWallets = { evmChains: { data: [{ address, privateKey: encryptedPrivKey, isDeleted: false, isImported: true }] } };
@@ -333,8 +335,6 @@ class Keyring {
             }
         } else {
             const { response: mnemonic } = await this.exportMnemonic(pin);
-
-            let address;
 
             if (this[this.chain] === undefined) {
                 const keyringInstance = await helper.getCoinInstance(this.chain, mnemonic);
@@ -366,7 +366,7 @@ class Keyring {
 
         this.vault = vault;
 
-        return { response: vault };
+        return { response: { vault, address } };
     }
 
     async getActiveChains() {


### PR DESCRIPTION
Updated the `importWallet()` function to return the public address of the private key along with the encrypted vault string.