### PR TITLE
Bugfix - User was unable to export the private key of an imported non-evm chain wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,3 +190,9 @@ Deprecated package was `@getsafle/bsc-wallet-controller` and updated one is `@ge
 
 * Integrated BSC chain wallet scanning for `recoverVault()` function.
 * Integrated BSC chain for `getVaultDetails()` function.
+
+### 1.10.1 (2022-04-15)
+
+##### [Bugfix]: Fixed the bug where the user was unable to export the private keys of their bitcoin wallet
+
+* Fixed the bug where the user was unable to export the private keys of their bitcoin wallet

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/safle-vault",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Safle Vault is a non-custodial, flexible and highly available crypto wallet which can be used to access dapps, send/receive crypto and store identity. Vault SDK is used to manage the vault and provide methods to generate vault, add new accounts, update the state and also enable the user to perform several vault related operations.",
   "main": "src/index.js",
   "scripts": {

--- a/src/lib/keyring.js
+++ b/src/lib/keyring.js
@@ -114,23 +114,20 @@ class Keyring {
             throw ERROR_MESSAGE.INCORRECT_PIN_TYPE
         }
 
-        let chain = (Chains.evmChains.hasOwnProperty(this.chain) || this.chain === 'ethereum') ? 'eth' : this.chain;
+        const chain = (Chains.evmChains.hasOwnProperty(this.chain) || this.chain === 'ethereum') ? 'eth' : this.chain;
+        const importedChain = (chain === 'eth') ? 'evmChains' : chain;
 
         let isImportedAddress;
 
-        if (chain === 'eth' && this.decryptedVault.importedWallets !== undefined && this.decryptedVault.importedWallets.evmChains !== undefined && this.decryptedVault.importedWallets.evmChains.data.some(element => element.address === address) == true) {
+        if (this.decryptedVault.importedWallets !== undefined && this.decryptedVault.importedWallets[importedChain] !== undefined && this.decryptedVault.importedWallets[importedChain].data.some(element => element.address === address) == true) {
             isImportedAddress = true;
-        } else if (this.decryptedVault.importedWallets !== undefined && this.decryptedVault.importedWallets[chain] !== undefined && this.decryptedVault.importedWallets[chain].data.some(element => element.address === address) == true) {
-            isImportedAddress = true;
-        } else {
+        } else if (this.decryptedVault[chain] !== undefined && this.decryptedVault[chain].public.some(element => element.address === address) == true) {
             isImportedAddress = false;
-        }
-
-        if (!this.decryptedVault[chain] || (this.decryptedVault[chain].public.some(element => element.address === address) == false && isImportedAddress == false)) {
+        } else {
             return { error: ERROR_MESSAGE.ADDRESS_NOT_PRESENT };
         }
 
-        const { response } = await this.validatePin(pin)
+        const { response } = await this.validatePin(pin);
 
         if (response == false) {
             return { error: ERROR_MESSAGE.INCORRECT_PIN };


### PR DESCRIPTION
Fixed the bug in the conditional statements for export private key function.

Even if the address was present in the vault, the function returned the error : `This address is not present in the vault`.