### PR TITLE
Prevent user from importing an already existing wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,3 +190,16 @@ Deprecated package was `@getsafle/bsc-wallet-controller` and updated one is `@ge
 
 * Integrated BSC chain wallet scanning for `recoverVault()` function.
 * Integrated BSC chain for `getVaultDetails()` function.
+
+### 1.10.1 (2022-04-15)
+
+##### [Bugfix]: Fixed the bug where the user was unable to export the private keys of their bitcoin wallet
+
+* Fixed the bug where the user was unable to export the private keys of their bitcoin wallet
+
+### 1.10.2 (2022-04-15)
+
+##### [Bugfix]: `importWallet()` function can be used to import an already existing wallet
+
+* `importWallet()` function throws an error if the address is already present in the vault.
+* Implemented lodash library to query the nested object keys for all functions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/safle-vault",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/safle-vault",
-  "version": "1.10.0",
+  "version": "1.10.2",
   "description": "Safle Vault is a non-custodial, flexible and highly available crypto wallet which can be used to access dapps, send/receive crypto and store identity. Vault SDK is used to manage the vault and provide methods to generate vault, add new accounts, update the state and also enable the user to perform several vault related operations.",
   "main": "src/index.js",
   "scripts": {
@@ -51,6 +51,7 @@
     "ethereumjs-util": "^7.1.2",
     "ethers": "^5.5.3",
     "get-random-values": "^1.2.2",
+    "lodash": "^4.17.21",
     "loglevel": "^1.7.1",
     "obs-store": "^4.0.3",
     "web3": "^1.3.5"

--- a/src/constants/responses/index.js
+++ b/src/constants/responses/index.js
@@ -9,4 +9,5 @@ module.exports = {
     CHAIN_NOT_SUPPORTED: 'The selected chain is not supported',
     UNSUPPORTED_NON_EVM_FUNCTIONALITY: 'This functionality is not supported for non-EVM chains.',
     INCORRECT_PIN_TYPE: 'The pin should be a positive integer value',
+    ADDRESS_ALREADY_PRESENT: 'This address is already present in the vault'
 };


### PR DESCRIPTION
- Added checking to ensure the user cannot import an existing wallet.
- Used `.get()` function in the [lodash](https://www.npmjs.com/package/lodash) library to query and traverse the nested object keys for all functions.