### PR TITLE
[Bugfix] Added error handling for `validateMnemonic()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,3 +308,9 @@ Deprecated package was `@getsafle/bsc-wallet-controller` and updated one is `@ge
 ##### Removed `velas`, `avalanche`, `solana` and `harmony` chain integration.
 
 * Removed `velas`, `avalanche`, `solana` and `harmony` chain integration.
+
+### 1.18.1 (2022-06-13)
+
+##### Uncaught error in `validateMnemonic()`.
+
+* Added error handling for an uncaught error when user inputs an invalid mnemonic in the `validateMnemonic()` function .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/safle-vault",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Safle Vault is a non-custodial, flexible and highly available crypto wallet which can be used to access dapps, send/receive crypto and store identity. Vault SDK is used to manage the vault and provide methods to generate vault, add new accounts, update the state and also enable the user to perform several vault related operations.",
   "main": "src/index.js",
   "scripts": {

--- a/src/lib/keyring.js
+++ b/src/lib/keyring.js
@@ -67,7 +67,15 @@ class Keyring {
 
         const safle = new SafleId(network);
 
-        const { address } = await ethers.Wallet.fromMnemonic(mnemonic);
+        let address;
+
+        try {
+            const wallet = ethers.Wallet.fromMnemonic(mnemonic);
+
+            address = wallet.address;
+        } catch (e) {
+            return { response: false };
+        }
 
         const safleId = await safle.getSafleId(address);
 


### PR DESCRIPTION
Added error handling for `validateMnemonic()` function for when the user inputs an invalid seed phrase  or if the seed phrase checksum fails