### PR TITLE
Updated `safle-identity-wallet` library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,3 +314,10 @@ Deprecated package was `@getsafle/bsc-wallet-controller` and updated one is `@ge
 ##### Uncaught error in `validateMnemonic()`.
 
 * Added error handling for an uncaught error when user inputs an invalid mnemonic in the `validateMnemonic()` function .
+
+### 1.18.2 (2022-06-24)
+
+##### Updated `safle-identity-wallet` package version.
+
+* Updated `safle-identity-wallet` package version.
+* [Breaking Change] - `validateMnemonic()` also accepts polygonRpcUrl.

--- a/README.md
+++ b/README.md
@@ -117,11 +117,12 @@ This method is used to delete an account from the vault.
 Validate Mnemonic:
 This method is used to validate the user's mnemonic by querying the first 0th address for its safleId.
 
-`const isMnemonicValid = await vault.validateMnemonic(mnemonic, safleID, network);`
+`const isMnemonicValid = await vault.validateMnemonic(mnemonic, safleID, network, polygonRpcUrl);`
  
 * `mnemonic` - The mnemonic phrase to be validated.
 * `safleID` - The safleId of the user.
-* `networks` - The network to query the safleId. Valid values - `mainnet` or `testnet`.
+* `network` - The network to query the safleId. Valid values - `mainnet` or `testnet`.
+* `polygonRpcUrl` - Polygon RPC URL. Must provide mainnet rpc if `network` is `mainnet` else mumbai rpc.
 
 Recover Vault:
 This method is used to recover the vault using the mnemonic phrase. The new vault will be re-encrypted using the pin and encryption key.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/safle-vault",
-  "version": "1.17.1",
+  "version": "1.18.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1721,12 +1721,12 @@
       }
     },
     "@getsafle/safle-identity-wallet": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@getsafle/safle-identity-wallet/-/safle-identity-wallet-1.0.1.tgz",
-      "integrity": "sha512-2ToHctSxoW69QPTUdFUUbfRUIY6wKRG8RqO2Rl+BOI8sVA9ZAMz3jlK41xB+RZ4KwSzFhSuwuHd43mHeVcgA1w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@getsafle/safle-identity-wallet/-/safle-identity-wallet-1.3.0.tgz",
+      "integrity": "sha512-FLDIiZwImk7hcwbqeYwSng799LpPTW1rD7deVa+xnSWg7JyAGZua3cxyqcnxpPVaOvcvPNBVleenUObjJzZ8SQ==",
       "requires": {
         "ethereumjs-tx": "^2.1.2",
-        "web3": "^1.2.6"
+        "web3": "^1.3.5"
       }
     },
     "@getsafle/transaction-controller": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/safle-vault",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "Safle Vault is a non-custodial, flexible and highly available crypto wallet which can be used to access dapps, send/receive crypto and store identity. Vault SDK is used to manage the vault and provide methods to generate vault, add new accounts, update the state and also enable the user to perform several vault related operations.",
   "main": "src/index.js",
   "scripts": {
@@ -35,7 +35,7 @@
     "@ethereumjs/common": "^2.5.0",
     "@ethereumjs/tx": "^3.3.2",
     "@getsafle/asset-controller": "^1.0.7",
-    "@getsafle/safle-identity-wallet": "^1.0.1",
+    "@getsafle/safle-identity-wallet": "^1.3.0",
     "@getsafle/transaction-controller": "^1.5.0",
     "@getsafle/vault-bitcoin-controller": "^1.1.0",
     "@getsafle/vault-bsc-controller": "^1.2.0",

--- a/src/lib/keyring.js
+++ b/src/lib/keyring.js
@@ -60,12 +60,12 @@ class Keyring {
         return { response: true };
     }
 
-    async validateMnemonic(mnemonic, safleID, network) {
+    async validateMnemonic(mnemonic, safleID, network, polygonRpcUrl) {
         if (network !== 'mainnet' && network !== 'testnet') {
             throw ERROR_MESSAGE.INVALID_NETWORK;
         }
 
-        const safle = new SafleId(network);
+        const safle = new SafleId(network, polygonRpcUrl);
 
         let address;
 


### PR DESCRIPTION
Updated `safle-identity-wallet` library

[Breaking Change] - `validateMnemonic()` also accepts polygonRpcUrl.