### PR TITLE
Updated the recoverVault params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -427,3 +427,10 @@ Deprecated package was `@getsafle/bsc-wallet-controller` and updated one is `@ge
 
 * Roll back to version 1.18.4.
 * Updated the asset controller version.
+
+### 1.25.1 (2022-12-26)
+
+##### Fixed the parameters passed in the transaction controller
+
+* Updated the network name in the transaction controller parameter.
+* [Breaking change] - `recoverVault()` parameters are updated. rpcURL not required to pass. Etherscan, Polygonscan and BSCscan keys are replaced with unmarshal api key .

--- a/README.md
+++ b/README.md
@@ -150,15 +150,12 @@ This method is used to validate the user's mnemonic by querying the first 0th ad
 Recover Vault:
 This method is used to recover the vault using the mnemonic phrase. The new vault will be re-encrypted using the pin and encryption key.
 
- `const userVault = await vault.recoverVault(mnemonic, encryptionKey, pin, etherscanApiKey, polygonscanApiKey, bscscanApiKey, rpcUrl);`
+ `const userVault = await vault.recoverVault(mnemonic, encryptionKey, pin, unmarshalApiKey);`
 
 * `mnemonic` - The mnemonic of the vault to be recovered.
 * `encryptionKey` - The encryption key used to encrypt/decrypt the vault.
 * `pin` - The pin to access the vault's private functions.
-* `etherscanApiKey` - API Key of etherscan.
-* `polygonscanApiKey` - API Key of polygonscan.
-* `bscscanApiKey` - API Key of bscscan.
-* `rpcUrl` - rpcUrl of the eth chain.
+* `unmarshalApiKey` - API Key of unmarshal api.
 
 Validate PIN
 This method is used to validate the PIN of the user's vault

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/safle-vault",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "Safle Vault is a non-custodial, flexible and highly available crypto wallet which can be used to access dapps, send/receive crypto and store identity. Vault SDK is used to manage the vault and provide methods to generate vault, add new accounts, update the state and also enable the user to perform several vault related operations.",
   "main": "src/index.js",
   "scripts": {

--- a/src/lib/vault.js
+++ b/src/lib/vault.js
@@ -84,14 +84,14 @@ class Vault extends Keyring {
         return { response: vault };
     }
 
-    async recoverVault(mnemonic, encryptionKey, pin, etherscanApiKey, polygonscanApiKey, bscscanApiKey, rpcUrl) {
+    async recoverVault(mnemonic, encryptionKey, pin, unmarshalApiKey) {
         if (!Number.isInteger(pin) || pin < 0) {
             throw ERROR_MESSAGE.INCORRECT_PIN_TYPE
         }
 
         const vaultState = await this.keyringInstance.createNewVaultAndRestore(JSON.stringify(encryptionKey), mnemonic);
 
-        const accountsArray = await helper.removeEmptyAccounts(vaultState.keyrings[0].accounts[0], this.keyringInstance, vaultState, rpcUrl, etherscanApiKey, polygonscanApiKey, bscscanApiKey);
+        const accountsArray = await helper.removeEmptyAccounts(vaultState.keyrings[0].accounts[0], this.keyringInstance, vaultState, unmarshalApiKey);
 
         const privData = await helper.generatePrivData(mnemonic, pin);
 

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -27,9 +27,7 @@ async function generatePrivData(mnemonic, pin) {
   return priv;
 }
 
-async function removeEmptyAccounts(indexAddress, keyringInstance, vaultState, rpcURL, etherscanApiKey, polygonscanApiKey, bscscanApiKey) {
-  const web3 = new Web3(new Web3.providers.HttpProvider(rpcURL));
-
+async function removeEmptyAccounts(indexAddress, keyringInstance, vaultState, unmarshalApiKey) {
   const keyring = keyringInstance.getKeyringsByType(vaultState.keyrings[0].type);
 
   let zeroCounter = 0;
@@ -37,20 +35,14 @@ async function removeEmptyAccounts(indexAddress, keyringInstance, vaultState, rp
 
   accountsArray.push({ address: indexAddress, isDeleted: false, isImported: false, label: 'Wallet 1' });
 
-  let network;
-
-  await web3.eth.net.getNetworkType().then((e) => network = e);
-
-  network = network === 'main' ? network = 'mainnet' : network;
-
   do {
     zeroCounter = 0;
     for(let i=0; i < 5; i++) {
       const vaultState = await keyringInstance.addNewAccount(keyring[0]);
 
-      const ethActivity = await getETHTransactions(vaultState.keyrings[0].accounts[vaultState.keyrings[0].accounts.length - 1], network, etherscanApiKey);
-      const polygonActivity = await getPolygonTransactions(vaultState.keyrings[0].accounts[vaultState.keyrings[0].accounts.length - 1], 'polygon-mainnet', polygonscanApiKey);
-      const bscActivity = await getBSCTransactions(vaultState.keyrings[0].accounts[vaultState.keyrings[0].accounts.length - 1], 'bsc-mainnet', bscscanApiKey);
+      const ethActivity = await getETHTransactions(vaultState.keyrings[0].accounts[vaultState.keyrings[0].accounts.length - 1], 'ethereum', unmarshalApiKey);
+      const polygonActivity = await getPolygonTransactions(vaultState.keyrings[0].accounts[vaultState.keyrings[0].accounts.length - 1], 'polygon', unmarshalApiKey);
+      const bscActivity = await getBSCTransactions(vaultState.keyrings[0].accounts[vaultState.keyrings[0].accounts.length - 1], 'bsc', unmarshalApiKey);
 
       if (!ethActivity && !polygonActivity && !bscActivity) {
         accountsArray.push({ address: vaultState.keyrings[0].accounts[vaultState.keyrings[0].accounts.length - 1], isDeleted: true, isImported: false, label: `Wallet ${i + 2}` });


### PR DESCRIPTION
* Updated the network name in the transaction controller parameter.
* [Breaking change] - `recoverVault()` parameters are updated. rpcURL not required to pass. Etherscan, Polygonscan and BSCscan keys are replaced with unmarshal api key .