### PR TITLE
update pin error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -466,3 +466,7 @@
 ### 1.26.6 (2023-03-17)
 
 * Updated Readme
+
+### 1.26.7 (2023-05-08)
+
+* Updated error message for incorrect PIN type entry

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getsafle/safle-vault",
-  "version": "1.26.6",
+  "version": "1.26.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@getsafle/safle-vault",
-      "version": "1.26.5",
+      "version": "1.26.7",
       "license": "MIT",
       "dependencies": {
         "@ethereumjs/common": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/safle-vault",
-  "version": "1.26.6",
+  "version": "1.26.7",
   "description": "Safle Vault is a non-custodial, flexible and highly available crypto wallet which can be used to access dapps, send/receive crypto and store identity. Vault SDK is used to manage the vault and provide methods to generate vault, add new accounts, update the state and also enable the user to perform several vault related operations.",
   "main": "src/index.js",
   "scripts": {

--- a/src/constants/responses/index.js
+++ b/src/constants/responses/index.js
@@ -8,7 +8,7 @@ module.exports = {
     NO_ACCOUNTS_FOUND: 'No accounts found for this chain',
     CHAIN_NOT_SUPPORTED: 'The selected chain is not supported',
     UNSUPPORTED_NON_EVM_FUNCTIONALITY: 'This functionality is not supported for non-EVM chains.',
-    INCORRECT_PIN_TYPE: 'The pin should be a positive integer valueof 6 digits',
+    INCORRECT_PIN_TYPE: 'Wrong pin type, format or length',
     ADDRESS_ALREADY_PRESENT: 'This address is already present in the vault',
     SHOULD_BE_AN_ARRAY: 'Addresses and chains should be an array',
     INVALID_NETWORK: 'Invalid network selected',

--- a/src/lib/test/keyring.test.js
+++ b/src/lib/test/keyring.test.js
@@ -30,7 +30,7 @@ describe('exportMnemonic' , ()=>{
     test('Valid exportMnemonic/invalid pin' , async()=>{
         
         let result = await new KeyRing().exportMnemonic(1111)
-        expect(result.error).toBe('The pin should be a positive integer valueof 6 digits')
+        expect(result.error).toBe('Wrong pin type, format or length')
     })
     test('Valid exportMnemonic/INCORRECT_PIN' , async()=>{
         
@@ -46,7 +46,7 @@ describe('exportMnemonic' , ()=>{
 
         }
         catch(e){
-            expect(e).toBe('The pin should be a positive integer valueof 6 digits')
+            expect(e).toBe('Wrong pin type, format or length')
         }
         
     })
@@ -77,7 +77,7 @@ describe('validatePin' , ()=>{
 
         }
         catch(e){
-            expect(e).toBe('The pin should be a positive integer valueof 6 digits')
+            expect(e).toBe('Wrong pin type, format or length')
         }
         
     })
@@ -90,7 +90,7 @@ describe('validatePin' , ()=>{
 
         }
         catch(e){
-            expect(e).toBe('The pin should be a positive integer valueof 6 digits')
+            expect(e).toBe('Wrong pin type, format or length')
         }
         
     })
@@ -128,7 +128,7 @@ describe('addAccount' , ()=>{
     test('addAccount/empty pin' , async()=>{  
     
         let result = await vault.addAccount(bufView,null)
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits")
+        expect(result.error).toBe("Wrong pin type, format or length")
 
         
         
@@ -138,7 +138,7 @@ describe('addAccount' , ()=>{
     test('addAccount/invalid pin' , async()=>{  
         
         let result = await vault.addAccount(bufView,"123333")
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits")
+        expect(result.error).toBe("Wrong pin type, format or length")
         
         
         
@@ -154,7 +154,7 @@ describe('addAccount' , ()=>{
     test('addAccount/both param empty' , async()=>{  
        
         let result = await vault.addAccount("","")
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits")
+        expect(result.error).toBe("Wrong pin type, format or length")
 
         
         
@@ -187,14 +187,14 @@ describe('exportPrivateKey' , ()=>{
     test('exportPrivateKey/empty pin' , async()=>{ 
       
         let result = await vault.exportPrivateKey(accAddress,null)
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits")
+        expect(result.error).toBe("Wrong pin type, format or length")
         
     })
 
     test('exportPrivateKey/both empty' , async()=>{ 
         
         let result = await vault.exportPrivateKey(null,null)
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits")
+        expect(result.error).toBe("Wrong pin type, format or length")
         
     })
     test('exportPrivateKey/incorrect pin' , async()=>{ 
@@ -237,7 +237,7 @@ describe('importWallet' , ()=>{
     test('importWallet/empty pin' , async()=>{ 
        
         let result = await vault.importWallet("0x"+privateKey,null,bufView)
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits") 
+        expect(result.error).toBe("Wrong pin type, format or length") 
        
         
     })
@@ -258,7 +258,7 @@ describe('importWallet' , ()=>{
     test('importWallet/empty all params' , async()=>{ 
       
         let result = await vault.importWallet(null,null,null)
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits")
+        expect(result.error).toBe("Wrong pin type, format or length")
 
         
         
@@ -319,7 +319,7 @@ describe('restoreKeyringState',()=>{
     test('restoreKeyringState/empty pin' , async()=>{    
         
         let result= await vault.restoreKeyringState(vaultAddress,null,bufView)
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits")
+        expect(result.error).toBe("Wrong pin type, format or length")
 
         
        
@@ -330,7 +330,7 @@ describe('restoreKeyringState',()=>{
     test('restoreKeyringState/invalid pin' , async()=>{    
         
         let result= await vault.restoreKeyringState(vaultAddress,"avevr",bufView)
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits")
+        expect(result.error).toBe("Wrong pin type, format or length")
 
         
            
@@ -359,7 +359,7 @@ describe('restoreKeyringState',()=>{
     test('restoreKeyringState/all params empty' , async()=>{    
         
         let result= await vault.restoreKeyringState(null,null,null)
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits")
+        expect(result.error).toBe("Wrong pin type, format or length")
 
         
         
@@ -514,7 +514,7 @@ describe('sign',()=>{
         let data="hello world"
         
         let result = await vault.sign(data,"abc",null,ethUrl)
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits")    
+        expect(result.error).toBe("Wrong pin type, format or length")    
         
     })
     test('sign/icorrect pin' , async()=>{
@@ -529,7 +529,7 @@ describe('sign',()=>{
         
         let data="hello world"
         let result = await vault.sign(data,accAddress,"abc",ethUrl)
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits")
+        expect(result.error).toBe("Wrong pin type, format or length")
 
     })
 
@@ -558,7 +558,7 @@ describe('sign',()=>{
         let data="hello world"
        
         let result = await vault.sign(null,null,null,null)
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits")
+        expect(result.error).toBe("Wrong pin type, format or length")
         
         
     })
@@ -887,7 +887,7 @@ describe('changePin',()=>{
 
        }
         catch(e){
-            expect(e).toBe('The pin should be a positive integer valueof 6 digits')
+            expect(e).toBe('Wrong pin type, format or length')
         }
         
        
@@ -900,7 +900,7 @@ describe('changePin',()=>{
 
         }
         catch(e){
-            expect(e).toBe('The pin should be a positive integer valueof 6 digits')
+            expect(e).toBe('Wrong pin type, format or length')
         }
         
         
@@ -912,7 +912,7 @@ describe('changePin',()=>{
 
         }
         catch(e){
-            expect(e).toBe('The pin should be a positive integer valueof 6 digits')
+            expect(e).toBe('Wrong pin type, format or length')
         }
         
         
@@ -924,7 +924,7 @@ describe('changePin',()=>{
 
         }
         catch(e){
-            expect(e).toBe('The pin should be a positive integer valueof 6 digits')
+            expect(e).toBe('Wrong pin type, format or length')
         }
         
         
@@ -955,7 +955,7 @@ describe('changePin',()=>{
 
         }
         catch(e){
-            expect(e).toBe('The pin should be a positive integer valueof 6 digits')
+            expect(e).toBe('Wrong pin type, format or length')
         }
         
         
@@ -1016,7 +1016,7 @@ describe('deleteAccount',()=>{
     test('deleteAccount/empty pin' , async()=>{
        
         let result = await vault.deleteAccount(bufView,accAddress,null)
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits")
+        expect(result.error).toBe("Wrong pin type, format or length")
 
         
        
@@ -1026,7 +1026,7 @@ describe('deleteAccount',()=>{
     test('deleteAccount/invalid pin' , async()=>{
       
         let result = await vault.deleteAccount(bufView,accAddress,"efwe")
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits")
+        expect(result.error).toBe("Wrong pin type, format or length")
        
         
     })
@@ -1042,7 +1042,7 @@ describe('deleteAccount',()=>{
             let result = await vault.deleteAccount(null,null,null)
         }
         catch(e){
-            expect(e).toBe('The pin should be a positive integer valueof 6 digits')
+            expect(e).toBe('Wrong pin type, format or length')
 
         }
        
@@ -1190,7 +1190,7 @@ describe('signTransaction',()=>{
        
 
         let result = await vault.signTransaction("evwf",null,polygonRpcUrl)
-        expect(result.error).toBe('The pin should be a positive integer valueof 6 digits')
+        expect(result.error).toBe('Wrong pin type, format or length')
         
        
         
@@ -1216,7 +1216,7 @@ describe('signTransaction',()=>{
     
 
         let result = await vault.signTransaction("evwf","afewf",polygonRpcUrl)
-        expect(result.error).toBe('The pin should be a positive integer valueof 6 digits')
+        expect(result.error).toBe('Wrong pin type, format or length')
 
         
         
@@ -1331,7 +1331,7 @@ describe('signTransaction',()=>{
         let invalidRpc="efrwgrwdvfr"
         
             let result = await vault.signTransaction(null,null,null)
-            expect(result.error).toBe("The pin should be a positive integer valueof 6 digits")
+            expect(result.error).toBe("Wrong pin type, format or length")
 
         
        

--- a/src/lib/test/vault.test.js
+++ b/src/lib/test/vault.test.js
@@ -59,7 +59,7 @@ describe("generateVault",()=>{
         const bufView = new Uint8Array(buf);
        
         let result = await new Vault().generateVault(bufView,null,Mnemonic)
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits") 
+        expect(result.error).toBe("Wrong pin type, format or length") 
 
     })
 
@@ -67,7 +67,7 @@ describe("generateVault",()=>{
         const buf = new ArrayBuffer(32);
         const bufView = new Uint8Array(buf);
         let result = await new Vault().generateVault(null,1111,Mnemonic)
-        expect(result.error).toBe('The pin should be a positive integer valueof 6 digits')
+        expect(result.error).toBe('Wrong pin type, format or length')
     
     })
     test('generateVault/empty encrption key' , async()=>{
@@ -96,7 +96,7 @@ describe("generateVault",()=>{
         const bufView = new Uint8Array(buf);
       
         let result = await new Vault().generateVault(null,null,null)
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits") 
+        expect(result.error).toBe("Wrong pin type, format or length") 
     
               
     
@@ -151,7 +151,7 @@ describe("recoverVault",()=>{
     test('recoverVault/empty pin' , async()=>{
        
         let result = await vault.recoverVault(phrase,bufView,null,'BgoGMHvB5R7iMNhZ2BoJd470aSZNEz9t2N8PBOWD')
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits") 
+        expect(result.error).toBe("Wrong pin type, format or length") 
         
        
       
@@ -159,7 +159,7 @@ describe("recoverVault",()=>{
     test('recoverVault/invalid pin' , async()=>{
        
         let result = await vault.recoverVault(phrase,bufView,"aefew",'BgoGMHvB5R7iMNhZ2BoJd470aSZNEz9t2N8PBOWD')
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits") 
+        expect(result.error).toBe("Wrong pin type, format or length") 
         
       
     })
@@ -188,7 +188,7 @@ describe("recoverVault",()=>{
     test('recoverVault/all empty params' , async()=>{
        
         let result = await vault.recoverVault(null,null,null,null)
-        expect(result.error).toBe("The pin should be a positive integer valueof 6 digits") 
+        expect(result.error).toBe("Wrong pin type, format or length") 
         
        
       


### PR DESCRIPTION
prevent data leakage issue by using a generic error message for incorrect pin entry.
Information Leakage through Error Messages #206 