### PR TITLE
fix: Users can add duplicate labels to wallets

### DIFF
--- a/src/lib/keyring.js
+++ b/src/lib/keyring.js
@@ -1567,6 +1567,20 @@ class Keyring {
 
     const importedChain = chain === "eth" ? "evmChains" : chain;
 
+    // Check if the label is already taken by an active wallet
+    const isLabelTaken = Object.values(this.decryptedVault).some((vaultChain) => {
+      if (vaultChain.public) {
+        return vaultChain.public.some(
+          (wallet) => wallet.label === newLabel && !wallet.isDeleted
+        );
+      }
+      return false;
+    });
+
+    if (isLabelTaken) {
+      return { error: "This label is already taken by another wallet." };
+    }
+
     let objIndex;
 
     if (


### PR DESCRIPTION
This PR resolves an issue allowing users to assign duplicate labels to active wallets. It introduces validation in the updateLabel method to block duplicates among active wallets, while still permitting reuse of labels from deleted wallets. An error is thrown if the new label is already in use by an active wallet, ensuring uniqueness. The original functionality remains intact.